### PR TITLE
*WIP* trying to fix the "mvn test" failures

### DIFF
--- a/src/main/java/me/itzg/tryetcdworkpart/config/WorkerProperties.java
+++ b/src/main/java/me/itzg/tryetcdworkpart/config/WorkerProperties.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 public class WorkerProperties {
 
   @DurationUnit(ChronoUnit.SECONDS)
-  Duration leaseDuration = Duration.ofSeconds(5);
+  Duration leaseDuration = Duration.ofSeconds(500);
 
   @DurationUnit(ChronoUnit.SECONDS)
   Duration rebalanceDelay = Duration.ofSeconds(1);


### PR DESCRIPTION
## Tests:
I tried running tests in series of 20:
```
for x in $(seq -w 00 19); 
   do echo running $x; 
   date; time mvn test >& gun$x.txt; tail gun$x.txt; 
   pkill -9 java ;done
```

## master branch
Running vanilla master, it usually hangs by the 3 or 4th run, and never finishes all 20.

If I increase the ttl to 500 in the master branch:
https://github.com/GeorgeJahad/try-etcd-work-allocator/blob/george/handleTxnFailure/src/main/java/me/itzg/tryetcdworkpart/config/WorkerProperties.java#L17

It fails 95% of the time, but no longer hangs.

When looking at the failures, I noticed logs like this:
```
Rebalancing workLoad=8 to target=3
```
But this was for a test where the totalWorkItems were set to 6, so I knew the state was getting messed up.  I added log messages to confirm that transactions were failing, and guessed that that was the reason.

## this pr
So this PR attempts to rationalize the state variables by changing/restoring *ourWork*, and *workload* with the semaphor aquired after the results of the transaction are known.

With these changes it fails around 15-25% of the time.

I haven't cleaned it up for checkin, but you said you might want to take a look.

## lease keep alive
In addition, I created a separate PR where I tried to address the keepAlive listener issues you mentioned in chat.  It didn't seem to improve the pass rate beyond my other changes.  But I'm not actually sure what to do with the listener.  It doesn't seem documented anywhere.  So maybe I'm missing something.

That PR is here:
https://github.com/GeorgeJahad/try-etcd-work-allocator/pull/1
